### PR TITLE
Do not attempt to run the image if the build failed

### DIFF
--- a/build-and-run-toolbox-image.sh
+++ b/build-and-run-toolbox-image.sh
@@ -18,6 +18,9 @@ else
 fi
 # You can use --no-cache if you want to ensure a fresh build every time
 
+# Exit if the build failed
+[[ $? -ne 0 ]] && exit 1
+
 # Run the toolbox image and remove it after exit
 echo "Running the script contained in the toolbox image: $TOOLBOX_IMAGE_NAME:$TOOLBOX_IMAGE_TAG"
 podman run -it --rm --env-file "$ENV_FILE" $TOOLBOX_IMAGE_NAME:$TOOLBOX_IMAGE_TAG


### PR DESCRIPTION
If the build fails, do not attempt to run the image. If the image is not found, podman asks for an image repository to download the image from. The user may not realized that the build failed.